### PR TITLE
Added missing "$" to variable name on line 819

### DIFF
--- a/magick-slicer.sh
+++ b/magick-slicer.sh
@@ -816,7 +816,7 @@ debugMsg "Section: Slicer B"
 zoomPixels(){ # zoom tileSize
     local zoom=$1
     local pixels=$2
-    if [ "zoom" -ne 0 ]
+    if [ "$zoom" -ne 0 ]
     then
         let "pixels = pixels * 100"
         for(( i=0; i<zoom; i++ ))


### PR DESCRIPTION
Without the "$", some shells would try to evaluate it as a string instead of an int. This would result in an infinite loop of "Expecting Integer Expression" errors.