### PR TITLE
Fixed inability to disable dziFormat

### DIFF
--- a/magick-slicer.sh
+++ b/magick-slicer.sh
@@ -484,7 +484,8 @@ do
         ;;
 
         -d|--dzi)
-            dziFormat=true
+            dziFormat="$2"
+            shift # past argument
         ;;
 
         -a|--slicea)
@@ -721,7 +722,7 @@ sliceImage(){ # zoom image
     local tilesFormat="%[fx:page.x/${tileW}]${xyDelim}%[fx:page.y/${tileH}]" # This very important magic! It allow imagemagick to generate tile names with it position and place it in corect folders (but folders need to generate manually)
     local file="${resultDir}/${zoom}/%[filename:tile].${resultExt}"
 
-    if [ ! $dziFormat ]
+    if [ "$dziFormat" = false ]
     then
         # Creating subdirectories for tiles (one vertical line of tiles is in one folder)
         local srcSize=`getImgW $src`            # Getting image width


### PR DESCRIPTION
-d / --dziFormat was hardcoded to set dziFormat to true. dziFormat is already defaulted to true. Changed to -d takes boolean true/false.
In sliceImage "if [ ! dziFormat ] " was testing if the variable was unset on some shells. Changed to string comparison for greater portability.